### PR TITLE
Fix links

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,4 @@
 * link:{attachmentsdir}/api-reference.html[Devfile API Reference]
 * xref:assembly_making-a-workspace-portable-using-a-devfile.adoc[Guide for Stack Authors]
 * xref:migration_guide.adoc[Devfile v2 Migration Guide]
-* https://github.com/devfile/kubernetes-api/tree/master/samples/devfiles[Devfile Samples]
+* https://github.com/devfile/api/tree/master/samples/devfiles[Devfile Samples]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,4 @@
 * link:{attachmentsdir}/api-reference.html[Devfile API Reference]
 * xref:assembly_making-a-workspace-portable-using-a-devfile.adoc[Guide for Stack Authors]
 * xref:migration_guide.adoc[Devfile v2 Migration Guide]
-* https://github.com/devfile/kubernetes-api/tree/master/devfile-support/samples[Devfile Samples]
+* https://github.com/devfile/kubernetes-api/tree/master/samples/devfiles[Devfile Samples]

--- a/docs/modules/ROOT/pages/assembly_making-a-workspace-portable-using-a-devfile.adoc
+++ b/docs/modules/ROOT/pages/assembly_making-a-workspace-portable-using-a-devfile.adoc
@@ -28,7 +28,7 @@ include::partial$ref_objects-supported-in-products.adoc[leveloffset=+1]
 
 .Additional resources
 
-* link:https://github.com/devfile/kubernetes-api[Devfile specifications]
+* link:https://github.com/devfile/api[Devfile specifications]
 * link:https://devfile.github.io/website/[Devfile schema]
 * link:https://github.com/devfile/website[Documentation repo]
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -18,4 +18,4 @@ See xref:migration_guide.adoc[Devfile v2 Migration Guide].
 
 == Devfile v2.0 Examples
 
-See https://github.com/devfile/kubernetes-api/tree/master/devfile-support/samples[Devfile Samples].
+See https://github.com/devfile/api/tree/master/devfile-support/samples[Devfile Samples].

--- a/docs/modules/ROOT/pages/migration_guide.adoc
+++ b/docs/modules/ROOT/pages/migration_guide.adoc
@@ -81,7 +81,7 @@ Details can be found in the https://github.com/che-incubator/devworkspace-api/is
 
 === Out of Main Pod Compoenents
 
-Details can be found in the  https://github.com/devfile/kubernetes-api/issues/48[corresponding issue].
+Details can be found in the  https://github.com/devfile/api/issues/48[corresponding issue].
 
 === Replace Alias with Name
 
@@ -185,7 +185,7 @@ Details can be found in the https://github.com/che-incubator/devworkspace-api/is
 
 === Apply Command
 
-Details can be found in the https://github.com/devfile/kubernetes-api/issues/56[corresponding issue].
+Details can be found in the https://github.com/devfile/api/issues/56[corresponding issue].
 
 === Environment Varibables for a Specific Command
 
@@ -286,7 +286,7 @@ Details are in the https://github.com/che-incubator/devworkspace-api/issues/32[c
 
 == New metadata
 
-In v2 of the devfile we have added some new metadata like `version` (this is the https://github.com/che-incubator/devworkspace-api/issues/10[corresponding issue]) and some mandatory metadata for plugins (this is the https://github.com/devfile/kubernetes-api/issues/31[corresponding issue]).
+In v2 of the devfile we have added some new metadata like `version` (this is the https://github.com/che-incubator/devworkspace-api/issues/10[corresponding issue]) and some mandatory metadata for plugins (this is the https://github.com/devfile/api/issues/31[corresponding issue]).
 
 
 

--- a/docs/modules/ROOT/partials/con_a-minimal-devfile.adoc
+++ b/docs/modules/ROOT/partials/con_a-minimal-devfile.adoc
@@ -7,7 +7,7 @@
 
 The following is the minimum content required in a `devfile.yaml` file:
 
-* link:https://github.com/devfile/kubernetes-api/blob/master/schemas/devfile.json[schemaVersion]
+* link:https://github.com/devfile/api/blob/master/schemas/devfile.json[schemaVersion]
 * link:https://redhat-developer.github.io/devfile/devfile#metadata[metadata name]
 
 [source,yaml]


### PR DESCRIPTION
It fixes the links for devfile samples & devfile/api repo.

As far as I understand now, once it's merged - changes will be propagated to gh-pages branch via github action