### PR TITLE
Generate devfile registry index schema

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,8 +15,8 @@ jobs:
           version: 12.x
       - name: Checkout
         uses: actions/checkout@v2
-      - name: "Generate API Reference"
-        run: yarn install && yarn run generate-api-reference
+      - name: "Generate all schema"
+        run: yarn install && yarn run generate-all-schema
       - name: "Generate site using antora site action"
         uses: kameshsampath/antora-site-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 yarn-error.log
 docs/modules/ROOT/attachments/api-reference/
 docs/modules/ROOT/examples/api-reference/
+docs/modules/ROOT/attachments/registry-index-schema/
+docs/modules/ROOT/examples/registry-index-schema/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The generated JSON Schema documentation for the Devfile 2.0 is available here: h
 To build the documentation locally you need [Antora](https://antora.org/), node v10.12 or higher and yarn. Then from the root of this repository run:
 
 ```bash
-yarn install; yarn run generate-api-reference
+yarn install &&
+yarn run generate-all-schema &&
 antora antora-playbook.yml
 ```
 

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -60,7 +60,7 @@ commands:
       - type: exec
         component: antora
         workdir: /projects/docs
-        command: yarn install; ; yarn run generate-api-reference
+        command: yarn install; ; yarn run generate-all-schema
   - name: Start preview server
     actions:
       - type: exec

--- a/docs/modules/ROOT/attachments/jsonschemas/next/index.json
+++ b/docs/modules/ROOT/attachments/jsonschemas/next/index.json
@@ -1,0 +1,58 @@
+{
+    "title": "Devfile registry index schema - Version 2.0.0-alpha2",
+    "description": "Devfile registry index schema defines the structure of index.json in the devfile registry",
+    "type": "array",
+    "items": {
+        "description": "Devfile metadata",
+        "type": "object",
+        "properties": {
+            "name": {
+                "description": "The stack name",
+                "type": "string"
+            },
+            "displayName": {
+                "description": "The display name of devfile",
+                "type": "string"
+            },
+            "description": {
+                "description": "The description of devfile",
+                "type": "string"
+            },
+            "tags": {
+                "description": "The tags associated to devfile",
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "projectType": {
+                "description": "The project framework that is used in the devfile",
+                "type": "string"
+            },
+            "language": {
+                "description": "The project language that is used in the devfile",
+                "type": "string"
+            },
+            "links": {
+                "description": "Links related to the devfile",
+                "type": "object",
+                    "properties": {
+                    "<link>": {
+                        "type": "string"
+                    }
+                }
+            },
+            "starterProjects": {
+                "description": "The project templates that can be used in the devfile",
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}
+  
+  
+  
+  

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
 * xref:api-reference.adoc[]
+* xref:registry-index-schema.adoc[Devfile Registry Index Schema]
 * xref:assembly_making-a-workspace-portable-using-a-devfile.adoc[Guide for Stack Authors]
 * xref:migration_guide.adoc[Devfile v2 Migration Guide]
 * https://github.com/devfile/api/tree/master/samples/devfiles[Devfile Samples]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -9,6 +9,9 @@ Devfiles are consumed by tools that transform the definition into a cloud worksp
 
 See link:{attachmentsdir}/api-reference.html[Devfile API Reference].
 
+== Registry index schema
+
+See link:{attachmentsdir}/registry-index-schema.html[Devfile Registry Index Schema].
 
 == Guide for Stacks Authors
 

--- a/docs/modules/ROOT/pages/registry-index-schema.adoc
+++ b/docs/modules/ROOT/pages/registry-index-schema.adoc
@@ -1,0 +1,9 @@
+= Registry Index Schema
+:description: Devfile registry index schema
+:navtitle: Devfile registry index schema
+:keywords: devfile, registry, index, schema
+:page-aliases: _attachments:registry-index-schema
+
+++++
+include::example$registry-index-schema/next/body.html[]
+++++

--- a/generate-registry-index-schema.js
+++ b/generate-registry-index-schema.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const { Bootprint } = require('bootprint/index')
+const bootprintJsonSchema = require('bootprint-json-schema')
+const bootprintConfig = require('./reference-generator/config.js')
+const glob = require('glob-fs')();
+const fs = require('fs');
+
+fs.readdir('./docs/modules/ROOT/attachments/jsonschemas/', (err, files) => {
+    if (err) throw err;
+    files.forEach((version) => {
+        var schemas = glob.readdirSync('./docs/modules/ROOT/attachments/jsonschemas/' + version + '/index*.json');
+        if (! schemas.empty) {
+            var schemaPath = schemas[0]
+            var apiReferencePath = './docs/modules/ROOT/attachments/registry-index-schema/' + version + '/'
+            console.log("Generating registry index schema:\n  - from schema: " + schemaPath + '\n  - to folder: ' + apiReferencePath)
+            new Bootprint(bootprintJsonSchema, bootprintConfig)
+            .run(schemaPath, apiReferencePath)
+            .then((result) => {
+                try {
+                    fs.mkdirSync(`./docs/modules/ROOT/examples/registry-index-schema/${version}/`, { recursive: true })    
+                } catch(e) { console.error(e)}
+                fs.writeFileSync(
+                    `./docs/modules/ROOT/examples/registry-index-schema/${version}/body.html`,
+                    `
+                    <a href="_attachments/jsonschemas/${version}/index.json">Download current the JSON Schema</a>
+                    <iframe src="_attachments/registry-index-schema/${version}/index.html" style="border:none;width: 100%;min-height:50em;height:-webkit-fill-available;"></iframe>
+                    `)
+            }
+            , (err) => {
+                throw err
+            })
+        }
+    });
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "http-server": "^0.12.3"
   },
   "scripts": {
-    "generate-api-reference": "node generate-api-reference.js"
+    "generate-all-schema": "yarn run generate-api-reference && yarn run generate-registry-index-schema",
+    "generate-api-reference": "node generate-api-reference.js",
+    "generate-registry-index-schema": "node generate-registry-index-schema.js"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/devfile/api/issues/195

This PR is for generating and publishing devfile registry index schema to official website in the type of interactive json viewer, so that all consumers can view the devfile registry index schema on our official website and we can centralize devfile schema and devfile registry index schema in one place.

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>