### PR TITLE
Update node-setup in main.yaml.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Setup Node.js for use with actions
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v1
         with:
           version: 12.x
       - name: Checkout
@@ -33,7 +33,7 @@ jobs:
     name: "Deploy GitHub Pages"
     steps:
      - name: Setup Node.js for use with actions
-       uses: actions/setup-node@v1.1.0
+       uses: actions/setup-node@v1
        with:
          version: 12.x
      - name: Checkout


### PR DESCRIPTION
The `node-setup` GH action uses `v1.1.0`, which results in the following error:
```
Unable to process command '##[add-path]/opt/hostedtoolcache/node/12.19.0/x64/bin' successfully.
The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```
This went into effect on Nov 16.

Newer versions of the action have been patched (https://github.com/actions/setup-node/issues/212#issuecomment-728653127), so using `v1` should fix the problem.