### PR TITLE
Update gh-pages-deploy and other GH actions.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
          antora_playbook: antora-playbook.yml
       - name: "Upload generated site"
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v2
         with:
           name: site
           path: "${{ github.workspace }}/build/${{ env.SITE_DIR }}"
@@ -41,12 +41,12 @@ jobs:
        with:
           persist-credentials: false
      - name: Download generated site
-       uses: actions/download-artifact@v1
+       uses: actions/download-artifact@v2
        with:
          name: site
          path: "${{ github.workspace }}/${{ env.SITE_DIR }}"
      - name: Deploy to GitHub Pages
-       uses: JamesIves/github-pages-deploy-action@3.5.5
+       uses: JamesIves/github-pages-deploy-action@3.7.1
        with:
         # ACCESS_TOKEN: # optional
         GITHUB_TOKEN: "${{ secrets.DOCS_DEPLOY_TOKEN}}"


### PR DESCRIPTION
* Updates the `github-pages-deploy` action to `v3.7.1` (latest) to prevent the following error:
  ```
  Error: Unable to process command '::set-env name=DEPLOYMENT_STATUS::success' successfully.
  Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution 
  by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see:   
  https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
  ```
* Updates the following GH actions to latest versions (`v2`):
  * `upload-artifact`
  * `download-artifact`