### PR TITLE
Merge meta.yaml and devfile.yaml

### DIFF
--- a/docs/modules/ROOT/attachments/jsonschemas/next/devfile.json
+++ b/docs/modules/ROOT/attachments/jsonschemas/next/devfile.json
@@ -1432,6 +1432,29 @@
           "description": "Optional semver-compatible version",
           "type": "string",
           "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+        },
+        "displayName": {
+          "description": "Optional devfile display name",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional devfile description",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Optional devfile tags",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "icon": {
+          "description": "Optional devfile icon",
+          "type": "string"
+        },
+        "globalMemoryLimit": {
+          "description": "Optional devfile global memory limit",
+          "type": "string"
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

Fixes https://github.com/devfile/api/issues/172

This PR is used to move fields from meta.yaml to devfile.yaml in terms of documentation.