### PR TITLE
added links

### DIFF
--- a/docs/modules/user-guide/partials/ref_devfile-samples.adoc
+++ b/docs/modules/user-guide/partials/ref_devfile-samples.adoc
@@ -1,6 +1,7 @@
 [id="ref_devfile-samples_{context}"]
-= Devfile Samples
+= Devfile resources
 
-.Additional Resources
+.Additional resources
 
-* https://github.com/devfile/api/tree/master/samples/devfiles[Devfile Samples]
+* link:https://github.com/devfile/api/issues[Creating devfiles].
+* link:https://github.com/devfile/docs[Documenting devfiles].


### PR DESCRIPTION
For issue [#180](https://github.com/devfile/api/issues/180)

I've added links under our `Devfile Samples` page so users can access the docs repo as well. I thought a name change to `Devfile resources` would make it more intuitive to the users. If we like the name change idea, I'll have to change the name of the actual doc and in the TOC. 

I'm trying to give more context as to why users would even want to visit our repos. If anyone has suggestions for more context, that'd be appreciated. 

Also, to my knowledge, there's no communication channel to link users to, like a YouTube channel, blog page, Twitter account, etc. But those can be considerations, moving forward! 