### PR TITLE
Pull release docs from github for build purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,18 @@ from the newly created ```v.2.0.x``` branch.
    version: '2.1.0'
    prerelease: -alpha
    ```
-1. Modify `antora-playbook.yaml` to add content for the new release created:
+1. Modify `antora-playbook.yaml` to add content for the new release created (if not already covered by branch pattern ```v2.0.*```:
    ```
    content:
      sources:
        - branches: HEAD
          start_path: docs
          url: ./
-       - branches: v2.0.x
+       - branches: [v2.*]
          start_path: docs
-         url: ./
+         url: https://github.com/devfile/docs
    ```
+   Note: pulling the release branches from github rather than locally is required for the docs build workflow. 
 1. Build, test, commit and merge the changes     
    
    

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -14,9 +14,9 @@ content:
   - branches: HEAD
     start_path: docs
     url: ./
-  - branches: v2.0.x
+  - branches: [v2.*]
     start_path: docs
-    url: ./
+    url: https://github.com/devfile/docs
 output:
   destinations:
     - clean: true


### PR DESCRIPTION
Updated antora_playbook to pull the release branches from github. The problem was that the build workflow does not have access to the v2.0.x branch locally so only the master version of the docs is built and published.
If working on the v.2.0.x branch it's playbook pulls locally, so this update probably makes most sense. 