### PR TITLE
added more content and context to devfile resources

### DIFF
--- a/docs/modules/user-guide/partials/ref_devfile-samples.adoc
+++ b/docs/modules/user-guide/partials/ref_devfile-samples.adoc
@@ -5,6 +5,6 @@
 
 To view the source code for the devfile specification, visit the link:https://github.com/devfile/api[GitHub API repository].
 
-To track the creation of devfiles, review the link:https://github.com/devfile/api/issues[open issues].
+To track the development of the devfile specification, visit the link:https://github.com/devfile/api/issues[issue tracker].
 
 To build and contribute to the documentation, visit the link:https://github.com/devfile/docs[GitHub Docs repository].

--- a/docs/modules/user-guide/partials/ref_devfile-samples.adoc
+++ b/docs/modules/user-guide/partials/ref_devfile-samples.adoc
@@ -3,6 +3,8 @@
 
 .Additional resources
 
-To build and test devfiles, visit the link:https://github.com/devfile/api[GitHub API repository]. To see the creation of devfiles, review the open issues. 
+To view the source code for the devfile specification, visit the link:https://github.com/devfile/api[GitHub API repository].
+
+To track the creation of devfiles, review the link:https://github.com/devfile/api/issues[open issues].
 
 To build and contribute to the documentation, visit the link:https://github.com/devfile/docs[GitHub Docs repository].

--- a/docs/modules/user-guide/partials/ref_devfile-samples.adoc
+++ b/docs/modules/user-guide/partials/ref_devfile-samples.adoc
@@ -6,5 +6,3 @@
 To build and test devfiles, visit our link:https://github.com/devfile/api[GitHub API repository]. Here, you can also view open issues, so you can see the creation of devfiles.
 
 To build and contribute to the documentation, visit our link:https://github.com/devfile/docs[GitHub Docs repository].
-
-If you want to customize your online IDE with a devfile, Red Hat has a demonstration in this link:https://youtu.be/vnsLwtRz--w[YouTube video].

--- a/docs/modules/user-guide/partials/ref_devfile-samples.adoc
+++ b/docs/modules/user-guide/partials/ref_devfile-samples.adoc
@@ -3,6 +3,6 @@
 
 .Additional resources
 
-To build and test devfiles, visit our link:https://github.com/devfile/api[GitHub API repository]. Here, you can also view open issues, so you can see the creation of devfiles.
+To build and test devfiles, visit the link:https://github.com/devfile/api[GitHub API repository]. To see the creation of devfiles, review the open issues. 
 
-To build and contribute to the documentation, visit our link:https://github.com/devfile/docs[GitHub Docs repository].
+To build and contribute to the documentation, visit the link:https://github.com/devfile/docs[GitHub Docs repository].

--- a/docs/modules/user-guide/partials/ref_devfile-samples.adoc
+++ b/docs/modules/user-guide/partials/ref_devfile-samples.adoc
@@ -3,5 +3,8 @@
 
 .Additional resources
 
-* link:https://github.com/devfile/api/issues[Creating devfiles].
-* link:https://github.com/devfile/docs[Documenting devfiles].
+To build and test devfiles, visit our link:https://github.com/devfile/api[GitHub API repository]. Here, you can also view open issues, so you can see the creation of devfiles.
+
+To build and contribute to the documentation, visit our link:https://github.com/devfile/docs[GitHub Docs repository].
+
+If you want to customize your online IDE with a devfile, Red Hat has a demonstration in this link:https://youtu.be/vnsLwtRz--w[YouTube video].


### PR DESCRIPTION
Fixes [#180: add links](https://github.com/devfile/api/issues/180) 

I've added context and content to the devfile resource's page because as it is now, it does not provide much more than the rest of the docs do. If anyone has any ideas or suggestions as to what more we can add, I'd love to discuss. 

Note: the Youtube link for me works on my machine, but not when I build the doc from Antora...I kept it because I wanted a second opinion if a YouTube video would even be necessary or beneficial at this stage. 
