### PR TITLE
 included odo yaml samples in devfile authoring docs

### DIFF
--- a/docs/modules/user-guide/partials/proc_adding-a-name-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-a-name-to-a-devfile.adoc
@@ -19,6 +19,7 @@ Adding a name to a devfile is mandatory. Both `name` and `generateName` are opti
 schemaVersion: 2.0.0
 metadata:
   name: devfile-sample
+  version: 2.0.0
 ----
 
 . To specify a prefix for automatically generated workspace names, define the `generateName` attribute and don't define the `name` attribute. The workspace name will be in the `<generateName>YYYYY` format (for example, `devfile-sample-2y7kp`). `Y` is random `[a-z0-9]` character.
@@ -30,6 +31,7 @@ metadata:
 schemaVersion: 2.0.0
 metadata:
   name: devfile-sample
+  version: 2.0.0
 ----
 
 [NOTE]

--- a/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
@@ -23,6 +23,7 @@ This section describes how to add one or more projects to a devfile.
 schemaVersion: 2.0.0
 metadata:
   name: petclinic-dev-environment
+  version: 2.0.0
 projects:
   - name: petclinic
     git:
@@ -40,6 +41,7 @@ projects:
 schemaVersion: 2.0.0
 metadata:
   name: example-devfile
+  version: 2.0.0
 projects:
 - name: frontend
   git:
@@ -96,6 +98,7 @@ source:
 schemaVersion: 2.0.0
 metadata:
   name: my-project-dev
+  version: 2.0.0
 projects:
   - name: my-project-resource
     clonePath: resources/my-project

--- a/docs/modules/user-guide/partials/proc_adding-schema-version-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-schema-version-to-a-devfile.adoc
@@ -13,7 +13,12 @@ The `schemaVersion` attribute is mandatory in a devfile.
 ====
 [source,yaml]
 ----
+v2.0
+---
 schemaVersion: 2.0.0
+metadata:
+  name: devfile-sample
+  version: 2.0.0
 ----
 ====
 


### PR DESCRIPTION
Fixes [#312](https://github.com/devfile/api/issues/312)

See the similar PR #42 for previous discussion on this work. 

I looked at the [devfile properties content on the odo page](https://odo.dev/file-reference/#devfile-properties). I then streamlined its devfile code samples into our authoring stacks docs. Thus far, I've only done a handful of the docs to ensure this is what we want as we aim to utilize devfile specific content from odo.  

I know we discussed our devfile docs having a similar layout to the odo docs. I looked at the [markdown file of the odo page](https://raw.githubusercontent.com/openshift/odo/master/docs/file-reference/index.md), and it seems that odo gets its tables and split screen layout by having one huge doc. Unlike our authoring stacks which are multiple docs. Something to think about as we continue the work on our layout. 