### PR TITLE
fixed spelling error for referring to parent devfiles

### DIFF
--- a/docs/modules/user-guide/pages/refering-to-a-parent-devfile-in-a-devfile.adoc
+++ b/docs/modules/user-guide/pages/refering-to-a-parent-devfile-in-a-devfile.adoc
@@ -1,6 +1,0 @@
-:description: Refering to a parent devfile in a devfile
-:navtitle: Refering to a parent
-:keywords: authoring, stack, refering, parent
-:page-aliases: 
-
-include::partial$proc_refering-to-a-parent-devfile-in-a-devfile.adoc[]

--- a/docs/modules/user-guide/pages/referring-to-a-parent-devfile-in-a-devfile.adoc
+++ b/docs/modules/user-guide/pages/referring-to-a-parent-devfile-in-a-devfile.adoc
@@ -1,0 +1,6 @@
+:description: Referring to a parent devfile in a devfile
+:navtitle: Referring to a parent
+:keywords: authoring, stack, referring, parent
+:page-aliases:
+
+include::partial$proc_referring-to-a-parent-devfile-in-a-devfile.adoc[]

--- a/docs/modules/user-guide/partials/assembly_authoring-stacks.adoc
+++ b/docs/modules/user-guide/partials/assembly_authoring-stacks.adoc
@@ -21,11 +21,10 @@ This section describes how to write a stack using {prod}.
 * xref:adding-commands-to-a-devfile.adoc[]
 * xref:adding-components-to-a-devfile.adoc[]
 * xref:adding-attributes-to-a-devfile.adoc[]
-* xref:refering-to-a-parent-devfile-in-a-devfile.adoc[]
+* xref:referring-to-a-parent-devfile-in-a-devfile.adoc[]
 
 // [role="_additional-resources"]
 // == Additional resources (or Next steps)
 
 ifdef::parent-context-of-assembly_authoring-stacks[:context: {parent-context-of-assembly_authoring-stacks}]
 ifndef::parent-context-of-assembly_authoring-stacks[:!context:]
-

--- a/docs/modules/user-guide/partials/assembly_migrating-to-devfile-v2.adoc
+++ b/docs/modules/user-guide/partials/assembly_migrating-to-devfile-v2.adoc
@@ -18,7 +18,7 @@ The following documents explain how to migrate an existing v1.x devfile to a v2.
 * xref:migrating-components.adoc[]
 * xref:migrating-plug-ins.adoc[]
 * xref:migrating-commands.adoc[]
-* xref:refering-to-a-parent-devfile-in-a-devfile.adoc[]
+* xref:referring-to-a-parent-devfile-in-a-devfile.adoc[]
 * xref:adding-event-bindings.adoc[]
 
 [role="_additional-resources"]

--- a/docs/modules/user-guide/partials/proc_referring-to-a-parent-devfile-in-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_referring-to-a-parent-devfile-in-a-devfile.adoc
@@ -1,4 +1,4 @@
-[id="proc_refering-to-a-parent-devfile-in-a-devfile_{context}"]
+[id="proc_referring-to-a-parent-devfile-in-a-devfile_{context}"]
 = Referring to a parent devfile in a devfile
 
 [role="_abstract"]


### PR DESCRIPTION
Due to the misspelling of "referring" our "referring to a parent devfile doc" wouldn't render properly. See the attached screenshot. This PR has corrected the spelling and therefore will correct the rendering. See the second screenshot. 

<img width="326" alt="Screen Shot 2021-05-11 at 2 00 38 PM" src="https://user-images.githubusercontent.com/70717303/117863193-83ef4500-b261-11eb-9513-0d88c85a33b4.png">

<img width="341" alt="Screen Shot 2021-05-11 at 2 01 56 PM" src="https://user-images.githubusercontent.com/70717303/117863317-a1241380-b261-11eb-807d-f5e915b53a4d.png">

