### PR TITLE
Add Devfile Registry link to Overview

### DIFF
--- a/docs/modules/user-guide/partials/con_devfile.adoc
+++ b/docs/modules/user-guide/partials/con_devfile.adoc
@@ -38,3 +38,5 @@ Developers use devfiles to focus only on developing their applications. With dev
 * Work with devfiles: xref:authoring-stacks.adoc[]
 * Update devfiles: xref:migrating-to-devfile-v2.adoc[]
 * Learn more about devfiles: xref:devfile-samples.adoc[]
+* Devfile registry: link:https://registry.devfile.io/[registry.devfile.io]
+* Devfile registry source: link:https://github.com/devfile/registry[devfile/registry]


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

I was reading the overview page and noticed the devfile site did not have any mention of the devfile registry https://github.com/devfile/registry where all the devfiles are currently hosted.

I just added a link for now.

Preview:
![Screen Shot 2021-05-12 at 1 03 36 PM](https://user-images.githubusercontent.com/31771087/118015625-7d74d200-b322-11eb-9aa4-510583d5c11d.png)

