### PR TITLE
Modified language so it better adheres to IBM style guide

### DIFF
--- a/docs/modules/user-guide/partials/proc_adding-attributes-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-attributes-to-a-devfile.adoc
@@ -2,7 +2,13 @@
 = Adding attributes to a devfile
 
 [role="_abstract"]
-Devfile attributes can be used to configure various features and properties according to user and tooling needs. Attributes are implementation-dependant, free-form YAML and can be defined for the following devfile objects: `metadata`, `components`, `commands`, `projects`, and `starterProjects`.
+You can use devfile attributes to configure various features and properties according to user and tooling needs. Attributes are implementation-dependent and written in free-form YAML; you can define attributes for the following devfile objects:
+
+* `metadata`
+* `components`
+* `commands`
+* `projects`
+* `starterProjects`
 
 .Prerequisites
 

--- a/docs/modules/user-guide/partials/proc_adding-attributes-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-attributes-to-a-devfile.adoc
@@ -2,7 +2,7 @@
 = Adding attributes to a devfile
 
 [role="_abstract"]
-You can use devfile attributes to configure various features and properties according to user and tooling needs. Attributes are implementation-dependent and written in free-form YAML; you can define attributes for the following devfile objects:
+Use devfile attributes to configure various features and properties according to user and tooling needs. Attributes are implementation-dependent and written in free-form YAML. The following devfile objects can have attributes:
 
 * `metadata`
 * `components`

--- a/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
@@ -2,7 +2,7 @@
 = Adding commands to a devfile
 
 [role="_abstract"]
-In your devfile, specify the commands to be executed in a workspace. Every command can contain a subset of actions. These subsets are related to a specific component and are executed in the container within the component.
+A devfile allows to specify commands to be available for execution in a workspace. Every command can contain a subset of actions. These subsets are related to specific components and are executed in the component containers.
 
 .Prerequisites
 

--- a/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
@@ -122,7 +122,7 @@ commands:
 
 . Composite command
 +
-You can define a composite command to chain multiple commands together. Reference the individual commands that are called from a composite command by the `name` of the command.  Specify a `parallel` boolean to determine if the commands within a composite command are being executed sequentially or in parallel.
+To chain multiple commands together, define a composite command. To reference the individual commands that are called from a composite command, use the `name` of the command. To specify whether commands within a composite command are to be executed sequentially or in parallel, define the `parallel` boolean.
 +
 [source,yaml]
 ----

--- a/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
@@ -2,7 +2,7 @@
 = Adding commands to a devfile
 
 [role="_abstract"]
-A devfile allows to specify commands to be available for execution in a workspace. Every command can contain a subset of actions, which are related to a specific component in whose container it will be executed.
+In your devfile, specify the commands to be executed in a workspace. Every command can contain a subset of actions. These subsets are related to a specific component and are executed in the container within the component.
 
 .Prerequisites
 
@@ -17,7 +17,13 @@ A devfile allows to specify commands to be available for execution in a workspac
 
 . For each command, define an unique value for the mandatory `id` attribute.
 
-. For each command, define a mandatory type of one of the following types: `exec`, `apply`, `composite`, or `vscode-tasks`.
+. For each command, define a mandatory type of one of the following types:
+
+* `exec`
+* `apply`
+* `composite`
+* `vscode-tasks`
+
 +
 .Sample command
 [source,yaml]
@@ -72,7 +78,14 @@ commands:
 
 . Command group
 +
-A given command can be assigned to one or more groups that represents the nature of the command.  The support groups are: `build`, `run`, `test` and `debug`. For each of the groups, one default command can be defined in each group by specifying the `isDefault` value.
+You can assign a given command to one or more groups that represents the nature of the command.  The support groups are:
++
+* `build`
+* `run`
+* `test`
+* `debug`
++
+For each of the groups, define one default command by specifying the `isDefault` value.
 +
 [source,yaml]
 ----
@@ -109,7 +122,7 @@ commands:
 
 . Composite command
 +
-A composite command can be defined to chain multiple commands together. The individual commands that are called from a composite command can be referenced by the `name` of the command.  A `parallel` boolean can be specified to determine if the commands within a composite command are being executed sequentially or in parallel.
+You can define a composite command to chain multiple commands together. Reference the individual commands that are called from a composite command by the `name` of the command.  Specify a `parallel` boolean to determine if the commands within a composite command are being executed sequentially or in parallel.
 +
 [source,yaml]
 ----

--- a/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
@@ -78,7 +78,7 @@ commands:
 
 . Command group
 +
-You can assign a given command to one or more groups that represents the nature of the command.  The support groups are:
+To assign a given command to one or more groups that represent the nature of the command, use the following supported group types:
 +
 * `build`
 * `run`

--- a/docs/modules/user-guide/partials/proc_adding-event-bindings.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-event-bindings.adoc
@@ -43,4 +43,4 @@ events:
 [role="_additional-resources"]
 .Additional resources
 
-For more information on adding event bindings, go to the following GitHub issue: link:https://github.com/devfile/api/issues/32[lifecycle bindings to bind commands].
+For more information on adding event bindings, see: link:https://github.com/devfile/api/issues/32[lifecycle bindings to bind commands].


### PR DESCRIPTION
Fixes #254 Review Language in Authoring Stacks.

Since I am doing a review of all the authoring stacks docs, I'll be making several PRs. I don't want any single PR to be too large, so I'll make a new PR for every several docs that I modify to meet the IBM Style Guide's requirements.