### PR TITLE
included odo lists throughout authoring stack docs

### DIFF
--- a/docs/modules/user-guide/partials/proc_adding-a-name-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-a-name-to-a-devfile.adoc
@@ -2,7 +2,13 @@
 = Adding a name to a devfile
 
 [role="_abstract"]
-Adding a name to a devfile is mandatory. Use the `name` or `generateName` attributes (or both) to define the name.
+Adding a name to a devfile is mandatory. Use the `name` or `generateName` attributes to define the name. See the following list for metadata properties in a devfile:
+
+[horizontal]
+Key:: metadataObject
+Type:: metadataObject
+Required:: no
+Description:: metadata to be used
 
 .Prerequisites
 

--- a/docs/modules/user-guide/partials/proc_adding-a-name-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-a-name-to-a-devfile.adoc
@@ -2,13 +2,22 @@
 = Adding a name to a devfile
 
 [role="_abstract"]
-Adding a name to a devfile is mandatory. Use the `name` or `generateName` attributes to define the name. See the following list for metadata properties in a devfile:
+Adding a name to a devfile is mandatory. Use the `name` attribute to define the name. See the following table for metadata properties in a devfile:
 
-[horizontal]
-Key:: metadataObject
-Type:: metadataObject
-Required:: no
-Description:: metadata to be used
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|name
+|string
+|yes
+|The name of your devfile. This name links you to the devfile registry if listed.
+
+|version
+|string
+|yes
+|The version of your devfile.
+|===
 
 .Prerequisites
 
@@ -27,23 +36,6 @@ metadata:
   name: devfile-sample
   version: 2.0.0
 ----
-
-. To specify a prefix for automatically generated workspace names, define the `generateName` attribute and not the `name` attribute.
-** The workspace name is in the `<generateName>YYYYY` format, for example, `devfile-sample-2y7kp`. `Y` is a random charater, `[a-z0-9]`.
-+
-.Adding a generated name to a devfile
-
-[source,yaml]
-----
-schemaVersion: 2.1.0
-metadata:
-  generateName: devfile-sample
-  version: 2.0.0
-----
-
-[NOTE]
-
-Defining `name` or `generateName` has the same effect when creating workspaces using a factory. The value forms the name prefix: `<name>YYYYY` or `<generateName>YYYYY`. When defining both `generateName` and `name`, `generateName` takes precedence.
 
 [role="_additional-resources"]
 .Additional resources

--- a/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
@@ -74,7 +74,7 @@ A devfile allows you to specify commands to be available for execution in a work
 |commands
 |string
 |no
-|The exec commands that constitute the composite command.
+|The exec commands that constitute the composite command and chains multiple commands together. 
 
 |parallel
 |boolean
@@ -106,7 +106,7 @@ A devfile allows you to specify commands to be available for execution in a work
 |boolean
 |no
 |Identifies if it is the default command to run. Only one default command can be defined for each group.
-|=== 
+|===
 
 .Prerequisites
 

--- a/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
@@ -2,13 +2,111 @@
 = Adding commands to a devfile
 
 [role="_abstract"]
-A devfile allows to specify commands to be available for execution in a workspace. Every command can contain a subset of actions. These subsets are related to specific components and are executed in the component containers. See the following list for command properties in a devfile:
+A devfile allows you to specify commands to be available for execution in a workspace. Every command can contain a subset of actions. These subsets are related to specific components and are executed in the component containers. See the following tables for command properties in a devfile:
 
-[horizontal]
-Key:: commandObject
-Type:: commandObject
-Required:: no
-Description:: command to be executed in an existing component container
+.commandObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|exec
+|execObject
+|no
+|The exec command to run.
+
+|composite
+|compositeObject
+|no
+|The composite command to run.
+|===
+
+.execObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|id
+|string
+|yes
+|The ID of the command.
+
+|commandLine
+|string
+|yes
+|The command to run.
+
+|component
+|string
+|no
+|The component to which the action relates.
+
+|label
+|string
+|no
+|The optional label to describe the command.
+
+|workingDir
+|string
+|no
+|The working directory where you execute the command.
+
+|group
+|groupObject
+|no
+|The group to which the command belongs.
+
+|environment
+|envObject
+|no
+|The list of environment variables you use.
+|===
+
+.compositeObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|id
+|string
+|yes
+|The ID of the command.
+
+|commands
+|string
+|no
+|The exec commands that constitute the composite command.
+
+|parallel
+|boolean
+|no
+|The flag that indicates if commands are executed in parallel.
+
+|label
+|string
+|no
+|The optional label to describe the command.
+
+|group
+|groupObject
+|no
+|The group to which the composite command belongs. The composite command cannot be of the `run` kind.
+|===
+
+.groupObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|kind
+|string
+|yes
+|The group to which the command belongs, such as: `build`, `run`, `test`, and `debug`.
+
+|isDefault
+|boolean
+|no
+|Identifies if it is the default command to run. Only one default command can be defined for each group.
+|=== 
 
 .Prerequisites
 
@@ -28,7 +126,6 @@ Description:: command to be executed in an existing component container
 * `exec`
 * `apply`
 * `composite`
-* `vscode-tasks`
 
 +
 .Sample command

--- a/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
@@ -2,7 +2,13 @@
 = Adding commands to a devfile
 
 [role="_abstract"]
-A devfile allows to specify commands to be available for execution in a workspace. Every command can contain a subset of actions. These subsets are related to specific components and are executed in the component containers.
+A devfile allows to specify commands to be available for execution in a workspace. Every command can contain a subset of actions. These subsets are related to specific components and are executed in the component containers. See the following list for command properties in a devfile:
+
+[horizontal]
+Key:: commandObject
+Type:: commandObject
+Required:: no
+Description:: command to be executed in an existing component container
 
 .Prerequisites
 

--- a/docs/modules/user-guide/partials/proc_adding-components-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-components-to-a-devfile.adoc
@@ -15,7 +15,7 @@ Each component in a single devfile must have a unique name and use one of the ob
 |The list of containers that you use.
 |===
 
-.containerObject
+.container object
 [cols="1,1,1,1"]
 |===
 |Key |Type| Required| Description
@@ -61,7 +61,7 @@ Each component in a single devfile must have a unique name and use one of the ob
 |The list of environment variables to use.
 |===
 
-.endpointObject
+.endpoint object
 [cols="1,1,1,1"]
 |===
 |Key |Type| Required| Description
@@ -89,7 +89,7 @@ Each component in a single devfile must have a unique name and use one of the ob
 |protocol
 |string
 |no
-|Use the following attributes to describe the application and transport protocols of the traffic that goes through the endpoint: `http`, `https`, `ws`, `wss`, `tcp`, `udp`. If not specified, the default attribute is `public`. 
+|Use the following attributes to describe the application and transport protocols of the traffic that goes through the endpoint: `http`, `https`, `ws`, `wss`, `tcp`, `udp`. If not specified, the default attribute is `http`.
 
 |secure
 |boolean
@@ -97,7 +97,7 @@ Each component in a single devfile must have a unique name and use one of the ob
 |Choose to define the endpoint as secure or not.
 |===
 
-.volumeObject
+.volume object
 [cols="1,1,1,1"]
 |===
 |Key |Type| Required| Description

--- a/docs/modules/user-guide/partials/proc_adding-components-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-components-to-a-devfile.adoc
@@ -2,7 +2,7 @@
 = Adding components to a devfile
 
 [role="_abstract"]
-Each component in a single devfile must have a unique name and use the `container` object. See the following tables for component properties in a devfile:
+Each component in a single devfile must have a unique name and use one of the objects: `container`, `kubernetes`, `openshift`, or `volume`. See the following tables for component properties in a devfile:
 
 .Component object
 [cols="1,1,1,1"]
@@ -79,7 +79,7 @@ Each component in a single devfile must have a unique name and use the `containe
 |exposure
 |string
 |no
-|Use the following attributes to describe how to expose the endpoints on the network: `public`, `internal`, `none`.
+|Use the following attributes to describe how to expose the endpoints on the network: `public`, `internal`, `none`. If not specified, the default attribute is `public`.
 
 |path
 |string
@@ -89,7 +89,7 @@ Each component in a single devfile must have a unique name and use the `containe
 |protocol
 |string
 |no
-|Use the following attributes to describe the application and transport protocols of the traffic that goes through the endpoint: `http`, `https`, `ws`, `wss`, `tcp`, `udp`.
+|Use the following attributes to describe the application and transport protocols of the traffic that goes through the endpoint: `http`, `https`, `ws`, `wss`, `tcp`, `udp`. If not specified, the default attribute is `public`. 
 
 |secure
 |boolean

--- a/docs/modules/user-guide/partials/proc_adding-components-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-components-to-a-devfile.adoc
@@ -2,13 +2,127 @@
 = Adding components to a devfile
 
 [role="_abstract"]
-Each component in a single devfile must have a unique name. See the following list for component properties in a devfile:
+Each component in a single devfile must have a unique name and use the `container` object. See the following tables for component properties in a devfile:
 
-[horizontal]
-Key:: componentObject
-Type:: componentObject
-Required:: no
-Description:: list of components to be used
+.Component object
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|container
+|componentObject
+|no
+|The list of containers that you use.
+|===
+
+.containerObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|name
+|string
+|yes
+|The name of your container.
+
+|image
+|string
+|yes
+|The image version.
+
+|memoryLimit
+|string
+|no
+|The memory limit that you use with your container.
+
+|mountSources
+|boolean
+|no
+|Choose to mount the source or not.
+
+|sourceMapping
+|string
+|no
+|The path in the container where you transfer and mount the project sources. This path is available in the container through the environment, `PROJECTS_ROOT`.
+
+|endpoints
+|endpointObject
+|no
+|The list of endpoints to use.
+
+|volumeMounts
+|volumeMountsObject
+|no
+|The list of volumes to mount.
+
+|environment
+|envObject
+|no
+|The list of environment variables to use.
+|===
+
+.endpointObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|name
+|string
+|yes
+|The name of your endpoint.
+
+|targetPort
+|integer
+|yes
+|The port number that you target.
+
+|exposure
+|string
+|no
+|Use the following attributes to describe how to expose the endpoints on the network: `public`, `internal`, `none`.
+
+|path
+|string
+|no
+|The path to the endpoint URL.
+
+|protocol
+|string
+|no
+|Use the following attributes to describe the application and transport protocols of the traffic that goes through the endpoint: `http`, `https`, `ws`, `wss`, `tcp`, `udp`.
+
+|secure
+|boolean
+|no
+|Choose to define the endpoint as secure or not.
+|===
+
+.volumeObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|name
+|string
+|yes
+|The name of the volume components that you use.
+
+|path
+|string
+|no
+|The path in the component container where you mount the volume.
+
+|name
+|string
+|yes
+|The name of the volume component.
+
+|size
+|string
+|no
+|The size of the storage you create.
+|===
+
 
 .Prerequisites
 

--- a/docs/modules/user-guide/partials/proc_adding-components-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-components-to-a-devfile.adoc
@@ -2,7 +2,13 @@
 = Adding components to a devfile
 
 [role="_abstract"]
-Each component in a single devfile must have a unique name.
+Each component in a single devfile must have a unique name. See the following list for component properties in a devfile:
+
+[horizontal]
+Key:: componentObject
+Type:: componentObject
+Required:: no
+Description:: list of components to be used
 
 .Prerequisites
 

--- a/docs/modules/user-guide/partials/proc_adding-event-bindings.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-event-bindings.adoc
@@ -2,13 +2,38 @@
 = Adding event bindings
 
 [role="_abstract"]
-This section describes how to add an event to a v2.x devfile. An event specified in a v1.x devfile still works in a v2.x devfile. See the following list for event properties in a devfile:
+This section describes how to add an event to a v2.x devfile. An event specified in a v1.x devfile still works in a v2.x devfile. An event can have three different type of objects:
 
-[horizontal]
-Key:: eventObject
-Type:: eventObject
-Required:: no
-Description:: events to be executed during a project lifecycle
+. preStartObject
+. postStartObject
+. preStopObject
+
+.preStartObject
+You can execute preStart events as init containers for the project pod in the order you specify the preStart events. The devfile `commandLine` and `workingDir` are the commands for the init container. As a result, the init container overwrites either the devfile or the container image `command` and `args`. If you use a composite command with `parallel: true`, the composite command executes as Kubernetes init containers.
+
+.postStartObject
+When you create the Kubernetes deployment for the `odo` component, execute the postStart events.
+
+.preStopObject
+Before you delete the Kubernetes deployment for the `odo` component, execute the preStop events.
+
+See the following list for event properties in a devfile:
+
+.envObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|name
+|string
+|yes
+|The name of the environment variable.
+
+|value
+|string
+|yes
+|The value of the environment variable.
+|===
 
 .Procedure
 

--- a/docs/modules/user-guide/partials/proc_adding-event-bindings.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-event-bindings.adoc
@@ -2,7 +2,13 @@
 = Adding event bindings
 
 [role="_abstract"]
-This section describes how to add an event to a v2.x devfile. An event specified in a v1.x devfile still works in a v2.x devfile.
+This section describes how to add an event to a v2.x devfile. An event specified in a v1.x devfile still works in a v2.x devfile. See the following list for event properties in a devfile:
+
+[horizontal]
+Key:: eventObject
+Type:: eventObject
+Required:: no
+Description:: events to be executed during a project lifecycle
 
 .Procedure
 

--- a/docs/modules/user-guide/partials/proc_adding-event-bindings.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-event-bindings.adoc
@@ -2,7 +2,7 @@
 = Adding event bindings
 
 [role="_abstract"]
-This section describes how to add an event to a v2.x devfile. An event specified in a v1.x devfile still works in a v2.x devfile. An event can have three different type of objects:
+This section describes how to add an event to a v2.x devfile. An event can have three different type of objects:
 
 . preStartObject
 . postStartObject

--- a/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
@@ -2,13 +2,103 @@
 = Adding projects to a devfile
 
 [role="_abstract"]
-This section describes how to add one or more projects to a devfile. See the following list for project properties in a devfile:
+This section describes how to add one or more projects to a devfile. Each starter project can contain three different objects:
 
-[horizontal]
-Key:: starterProjectObject
-Type:: starterProjectObject
-Required:: no
-Description:: list of starter projects to be used
+* git
+* github
+* zip
+
+See the following tables for project properties in a devfile:
+
+.starterProject object
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|name
+|string
+|no
+|The name of your devfile.
+
+|description
+|string
+|no
+|The description of your starterProject.
+
+|clonePath
+|string
+|no
+|The path relative to the root of your projects. Clone your projects into this path.
+|===
+
+
+.gitObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|location
+|string
+|no
+|The location of your git repository.
+
+|branch
+|string
+|no
+|The branch that you use.
+
+|spareCheckoutDir
+|string
+|no
+|The directory that you use when you pull from your repository.
+
+|startPoint
+|string
+|no
+|The tag or commit from where you start.
+|===
+
+.githubObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|location
+|string
+|no
+|The location of your git repository.
+
+|branch
+|string
+|no
+|The branch that you use.
+
+|spareCheckoutDir
+|string
+|no
+|The directory that you use when you pull from your repository.
+
+|startPoint
+|string
+|no
+|The tag or commit from where you start.
+|===
+
+.zipObject
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|location
+|string
+|no
+|The location of your zip.
+
+|spareCheckoutDir
+|string
+|no
+|The directory that you use when you pull from your repository.
+|===
 
 .Prerequisites
 

--- a/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
@@ -2,13 +2,7 @@
 = Adding projects to a devfile
 
 [role="_abstract"]
-This section describes how to add one or more projects to a devfile. Each starter project can contain three different objects:
-
-* git
-* github
-* zip
-
-See the following tables for project properties in a devfile:
+This section describes how to add one or more projects to a devfile. Each starter project can contain either a `git` or `zip` object. See the following tables for project properties in a devfile:
 
 .starterProject object
 [cols="1,1,1,1"]
@@ -17,7 +11,7 @@ See the following tables for project properties in a devfile:
 
 |name
 |string
-|no
+|yes
 |The name of your devfile.
 
 |description
@@ -37,51 +31,15 @@ See the following tables for project properties in a devfile:
 |===
 |Key |Type| Required| Description
 
-|location
+|checkoutFrom
 |string
 |no
 |The location of your git repository.
 
-|branch
+|remotes
 |string
 |no
 |The branch that you use.
-
-|spareCheckoutDir
-|string
-|no
-|The directory that you use when you pull from your repository.
-
-|startPoint
-|string
-|no
-|The tag or commit from where you start.
-|===
-
-.githubObject
-[cols="1,1,1,1"]
-|===
-|Key |Type| Required| Description
-
-|location
-|string
-|no
-|The location of your git repository.
-
-|branch
-|string
-|no
-|The branch that you use.
-
-|spareCheckoutDir
-|string
-|no
-|The directory that you use when you pull from your repository.
-
-|startPoint
-|string
-|no
-|The tag or commit from where you start.
 |===
 
 .zipObject
@@ -93,11 +51,6 @@ See the following tables for project properties in a devfile:
 |string
 |no
 |The location of your zip.
-
-|spareCheckoutDir
-|string
-|no
-|The directory that you use when you pull from your repository.
 |===
 
 .Prerequisites

--- a/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
@@ -2,8 +2,13 @@
 = Adding projects to a devfile
 
 [role="_abstract"]
-This section describes how to add one or more projects to a devfile.
+This section describes how to add one or more projects to a devfile. See the following list for project properties in a devfile:
 
+[horizontal]
+Key:: starterProjectObject
+Type:: starterProjectObject
+Required:: no
+Description:: list of starter projects to be used
 
 .Prerequisites
 

--- a/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
@@ -26,7 +26,7 @@ This section describes how to add one or more projects to a devfile. Each starte
 |===
 
 
-.gitObject
+.git object
 [cols="1,1,1,1"]
 |===
 |Key |Type| Required| Description
@@ -38,11 +38,11 @@ This section describes how to add one or more projects to a devfile. Each starte
 
 |remotes
 |string
-|no
+|yes
 |The branch that you use.
 |===
 
-.zipObject
+.zip object
 [cols="1,1,1,1"]
 |===
 |Key |Type| Required| Description

--- a/docs/modules/user-guide/partials/proc_adding-schema-version-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-schema-version-to-a-devfile.adoc
@@ -2,13 +2,17 @@
 = Adding schema version to a devfile
 
 [role="_abstract"]
-The `schemaVersion` attribute is mandatory in a devfile. See the following list for `schemaVersion` properties in a devfile:
+The `schemaVersion` attribute is mandatory in a devfile. See the following table for `schemaVersion` properties in a devfile:
 
-[horizontal]
-Key:: schemaVersion
-Type:: string
-Required:: yes
-Description:: v2.1.0 of the schema
+[cols="1,1,1,1"]
+|===
+|Key |Type| Required| Description
+
+|schemaVersion
+|string
+|yes
+|The version of the devfile schema that the devfile uses.
+|===
 
 .Procedure
 

--- a/docs/modules/user-guide/partials/proc_adding-schema-version-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-schema-version-to-a-devfile.adoc
@@ -2,8 +2,13 @@
 = Adding schema version to a devfile
 
 [role="_abstract"]
-The `schemaVersion` attribute is mandatory in a devfile.
+The `schemaVersion` attribute is mandatory in a devfile. See the following list for `schemaVersion` properties in a devfile:
 
+[horizontal]
+Key:: schemaVersion
+Type:: string
+Required:: yes
+Description:: v2.1.0 of the schema
 
 .Procedure
 


### PR DESCRIPTION
Fixes #312.

As a reference, I'm taking content the tables from [odo tables](https://odo.dev/file-reference/#devfile-properties) and including them throughout the authoring stacks docs. 

See the conversation in PR #69 where we thought that including the odo tables throughout the authoring stacks might be better than creating an entirely new doc. 