### PR TITLE
changed spelling in devfile registry 

### DIFF
--- a/docs/modules/user-guide/pages/devfile-registry.adoc
+++ b/docs/modules/user-guide/pages/devfile-registry.adoc
@@ -1,5 +1,5 @@
 :description: Devfile Registry
-:navtitle: devfile-registry
+:navtitle: Devfile registry
 :keywords: devfile
 // :page-aliases:
 


### PR DESCRIPTION
Currently, the `devfile registry` renders as `devfile-registry` in our TOC, which is not how we want it to look. See the screenshot: 
<img width="320" alt="Screen Shot 2021-07-07 at 9 07 36 AM" src="https://user-images.githubusercontent.com/70717303/124764283-c8fec300-df02-11eb-8b09-c0daa253c207.png">

With this PR, I simply corrected the capitalization, so `devfile registry` will look like all the other topics in our TOC. See the screenshot: 
<img width="675" alt="Screen Shot 2021-07-07 at 9 08 31 AM" src="https://user-images.githubusercontent.com/70717303/124764406-e9c71880-df02-11eb-8c77-220caa8acd3a.png">
