### PR TITLE
changed devfile samples to devfile resources

### DIFF
--- a/docs/modules/user-guide/nav.adoc
+++ b/docs/modules/user-guide/nav.adoc
@@ -29,4 +29,4 @@
 ** xref:referring-to-a-parent-devfile-in-a-devfile.adoc[]
 
 * xref:api-reference.adoc[]
-* xref:devfile-samples.adoc[]
+* xref:devfile-resources.adoc[]

--- a/docs/modules/user-guide/pages/devfile-resources.adoc
+++ b/docs/modules/user-guide/pages/devfile-resources.adoc
@@ -1,0 +1,6 @@
+:description: Devfile resources
+:navtitle: Devfile resources
+:keywords: devfile, resources
+:page-aliases: devfile_resources
+
+include::partial$ref_devfile-resources.adoc[]

--- a/docs/modules/user-guide/pages/devfile-samples.adoc
+++ b/docs/modules/user-guide/pages/devfile-samples.adoc
@@ -1,6 +1,0 @@
-:description: Devfile samples
-:navtitle: Devfile samples
-:keywords: devfile, samples
-:page-aliases: devfile_samples
-
-include::partial$ref_devfile-samples.adoc[]

--- a/docs/modules/user-guide/partials/ref_devfile-resources.adoc
+++ b/docs/modules/user-guide/partials/ref_devfile-resources.adoc
@@ -1,4 +1,4 @@
-[id="ref_devfile-samples_{context}"]
+[id="ref_devfile-resources_{context}"]
 = Devfile resources
 
 .Additional resources


### PR DESCRIPTION
Paul brought up a good concern about how we say `devfile samples` when we really mean `devfile resources.` See his PR #80. 

I've made this PR to change `samples` to `resources` in all our docs, including the nav.adoc and the docs' titles. Now, our TOC will render as `devfile resources.` See the screenshot below:
<img width="1038" alt="Screen Shot 2021-07-20 at 1 21 26 PM" src="https://user-images.githubusercontent.com/70717303/126368445-dcfda27a-f03b-4019-89c2-7bf7333e1d43.png">
 