### PR TITLE
omitted unneeded content in abstracts

### DIFF
--- a/docs/modules/user-guide/partials/proc_migrating-commands.adoc
+++ b/docs/modules/user-guide/partials/proc_migrating-commands.adoc
@@ -2,7 +2,7 @@
 = Migrating commands
 
 [role="_abstract"]
-This section describes how to migrate the `commands` section to a v2.x devfile. A command specified in a v1.x devfile does not work in a v2.x devfile.
+This section describes how to migrate the `commands` section to a v2.x devfile. 
 
 .Procedure
 

--- a/docs/modules/user-guide/partials/proc_migrating-components.adoc
+++ b/docs/modules/user-guide/partials/proc_migrating-components.adoc
@@ -2,7 +2,7 @@
 = Migrating components
 
 [role="_abstract"]
-This section describes how to migrate components to v2.x devfiles. A component specified in a v1.x devfile no longer works in a v2.x devfile.
+This section describes how to migrate components to v2.x devfiles.
 
 .Procedure
 

--- a/docs/modules/user-guide/partials/proc_migrating-plug-ins.adoc
+++ b/docs/modules/user-guide/partials/proc_migrating-plug-ins.adoc
@@ -2,7 +2,7 @@
 = Migrating plug-ins
 
 [role="_abstract"]
-This section describes how to migrate plug-ins to a v2.x devfile. A plug-in specified in a `meta.yaml` for a v1.x devfile no longer works in a v2.x devfile.
+This section describes how to migrate plug-ins to a v2.x devfile. 
 
 Additionally, v2.x devfiles include the following new features:
 

--- a/docs/modules/user-guide/partials/proc_migrating-projects.adoc
+++ b/docs/modules/user-guide/partials/proc_migrating-projects.adoc
@@ -2,7 +2,7 @@
 = Migrating projects
 
 [role="_abstract"]
-This section describes how to migrate projects to v2.x devfiles. A project specified in a v1.x devfile still works in a v2.x devfile.
+This section describes how to migrate projects to v2.x devfiles. 
 
 .Procedure
 

--- a/docs/modules/user-guide/partials/proc_migrating-schema-version.adoc
+++ b/docs/modules/user-guide/partials/proc_migrating-schema-version.adoc
@@ -2,7 +2,7 @@
 = Migrating schema version
 
 [role="_abstract"]
-This section describes how to migrate the existing schema version to a v2.x devfile. The schema version specified in a v1.x devfile still works in a v2.x devfile.
+This section describes how to migrate the existing schema version to a v2.x devfile.
 
 .Procedure
 


### PR DESCRIPTION
Throughout our migration docs, we have a redundant way of saying "projects in v1 devfiles still work in v2 devfiles." I went through our migration docs and removed this unnecessary phrasing. We can continue to  improve expand upon our abstracts in later PRs. 