### PR TITLE
changed samples to resources throughout our docs

### DIFF
--- a/docs/modules/user-guide/partials/proc_adding-attributes-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-attributes-to-a-devfile.adoc
@@ -43,4 +43,4 @@ components:
 .Additional resources
 
 * xref:api-reference.adoc[]
-* xref:devfile-samples.adoc[]
+* xref:devfile-resources.adoc[]

--- a/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-commands-to-a-devfile.adoc
@@ -74,7 +74,7 @@ A devfile allows you to specify commands to be available for execution in a work
 |commands
 |string
 |no
-|The exec commands that constitute the composite command and chains multiple commands together. 
+|The exec commands that constitute the composite command and chains multiple commands together.
 
 |parallel
 |boolean
@@ -270,4 +270,4 @@ commands:
 .Additional resources
 
 * xref:api-reference.adoc[]
-* xref:devfile-samples.adoc[]
+* xref:devfile-resources.adoc[]

--- a/docs/modules/user-guide/partials/proc_adding-components-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-components-to-a-devfile.adoc
@@ -152,4 +152,4 @@ Each component in a single devfile must have a unique name and use one of the ob
 
 
 * xref:api-reference.adoc[]
-* xref:devfile-samples.adoc[]
+* xref:devfile-resources.adoc[]

--- a/docs/modules/user-guide/partials/proc_adding-container-component-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-container-component-to-a-devfile.adoc
@@ -87,4 +87,4 @@ Use the `command` attribute of the `container` type to modify the `entrypoint` c
 .Additional resources
 
 * xref:api-reference.adoc[]
-* xref:devfile-samples.adoc[]
+* xref:devfile-resources.adoc[]

--- a/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-projects-to-a-devfile.adoc
@@ -181,4 +181,4 @@ For more information, see link:https://git-scm.com/docs/git-read-tree#_sparse_ch
 .Additional resources
 
 * xref:api-reference.adoc[]
-* xref:devfile-samples.adoc[]
+* xref:devfile-resources.adoc[]

--- a/docs/modules/user-guide/partials/proc_referring-to-a-parent-devfile-in-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_referring-to-a-parent-devfile-in-a-devfile.adoc
@@ -70,4 +70,4 @@ parent:
 For more information about referring to parent devfiles, see:
 
 * xref:api-reference.adoc[]
-* xref:devfile-samples.adoc[]
+* xref:devfile-resources.adoc[]


### PR DESCRIPTION
Since we changed `devfie samples` to `devfile resources` in PR 84:https://github.com/devfile/docs/pull/84, we need to go through our docs and locate every xref to `devfile samples` and change it to `devfile resources.` 

I've gone through all our docs, and now all the references are to `devfile resources` not `devfile samples.` See the screenshot below for an example: 
<img width="1001" alt="Screen Shot 2021-07-28 at 3 54 17 PM" src="https://user-images.githubusercontent.com/70717303/127387108-253b7357-5272-4224-a2bc-7f4fcf3b5cfa.png">
