### PR TITLE
CI: Add GHA for PR previews through Surge

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,20 @@
+name: Docs PR Preview
+
+on: [pull_request]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: afc163/surge-preview@v1
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: build/site
+          teardown: 'true'
+          build: |
+            npm install -g @antora/cli
+            yarn install
+            yarn run generate-api-reference
+            antora antora-playbook-for-development.yml


### PR DESCRIPTION
## Description

This PR adds a GHA Action to deploy preview PRs on Surge for easy reviews. 

JIRA ID: https://issues.redhat.com/browse/RHDEVDOCS-3339