### PR TITLE
fix parent reference example

### DIFF
--- a/docs/modules/user-guide/partials/proc_referring-to-a-parent-devfile-in-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_referring-to-a-parent-devfile-in-a-devfile.adoc
@@ -14,7 +14,7 @@ This section describes how to designate a parent devfile to a given devfile. If 
 
 You can refer to a parent devfile in three different ways:
 
-* `registry`
+* `id`
 * `uri`
 * `kubernetes`
 
@@ -30,7 +30,7 @@ metadata:
   name: my-project-dev
 parent:
     id: redhat/nodejs
-    registry: https://devfile-registry.io/
+    registryUrl: https://devfile-registry.io/
 ----
 ====
 +


### PR DESCRIPTION
`registry` is invalid key, it should be `registryUrl`