### PR TITLE
referenced go and odo correctly

### DIFF
--- a/docs/modules/user-guide/partials/assembly_devfile-library.adoc
+++ b/docs/modules/user-guide/partials/assembly_devfile-library.adoc
@@ -21,9 +21,9 @@ Using the devfile library, you can:
 * Generate Kubernetes objects for various devfile resources.
 * Define the `util` functions for the devfile.
 
-The library is written in Golang, and the following projects consume the library as a Golang dependency:
+The library is written in Go and the following projects consume the library as a Go dependency:
 
-* Odo
+* odo
 * OpenShift Console
 
 == Additional resources


### PR DESCRIPTION
Fixes https://github.com/devfile/api/issues/723 

Fixes https://issues.redhat.com/browse/RHDEVDOCS-3640

Simple changes to `Go` and `odo` 