### PR TITLE
included devfile converter in migration docs

### DIFF
--- a/docs/modules/user-guide/nav.adoc
+++ b/docs/modules/user-guide/nav.adoc
@@ -26,6 +26,7 @@
 *** xref:referring-to-a-parent-devfile-in-a-devfile.adoc[]
 
 ** xref:migrating-to-devfile-v2.adoc[]
+*** xref:installing-the-devfile-converter.adoc[]
 *** xref:migrating-schema-version.adoc[]
 *** xref:migrating-projects.adoc[]
 *** xref:migrating-components.adoc[]

--- a/docs/modules/user-guide/pages/installing-the-devfile-converter.adoc
+++ b/docs/modules/user-guide/pages/installing-the-devfile-converter.adoc
@@ -1,0 +1,6 @@
+:description: Installing the devfile-converter
+:navtitle: Installing the devfile-converter
+:keywords: devfile, converter
+:page-aliases:
+
+include::partial$proc_installing-the-devfile-converter.adoc[]

--- a/docs/modules/user-guide/partials/assembly_migrating-to-devfile-v2.adoc
+++ b/docs/modules/user-guide/partials/assembly_migrating-to-devfile-v2.adoc
@@ -11,9 +11,9 @@ endif::[]
 
 :context: assembly_migrating-to-devfile-v2
 
-The following documents explain how to migrate an existing v1.x devfile to a v2.x devfile:
+To migrate a devfile from version 1.x to 2.x, see the following documents:  
 
-* xref:installing-the-devfile-converter.adoc[] 
+* xref:installing-the-devfile-converter.adoc[]
 * xref:migrating-schema-version.adoc[]
 * xref:migrating-projects.adoc[]
 * xref:migrating-components.adoc[]

--- a/docs/modules/user-guide/partials/assembly_migrating-to-devfile-v2.adoc
+++ b/docs/modules/user-guide/partials/assembly_migrating-to-devfile-v2.adoc
@@ -13,6 +13,7 @@ endif::[]
 
 The following documents explain how to migrate an existing v1.x devfile to a v2.x devfile:
 
+* xref:installing-the-devfile-converter.adoc[] 
 * xref:migrating-schema-version.adoc[]
 * xref:migrating-projects.adoc[]
 * xref:migrating-components.adoc[]

--- a/docs/modules/user-guide/partials/proc_installing-the-devfile-converter.adoc
+++ b/docs/modules/user-guide/partials/proc_installing-the-devfile-converter.adoc
@@ -1,0 +1,21 @@
+[id="proc_installing-the-devfile-converter_{context}"]
+= Installing the devfile-converter
+
+[role="_abstract"]
+As you migrate an existing v1.x devfile to a v2.x devfile, consider using the devfile-converter.
+
+.Procedure
+
+* Install the devfile-converter:
++
+----
+$ import * as devfileConverter from '@eclipse-che/devfile-converter';
+----
++
+----
+$ async function v2ToV1(devfileV2: Devfile, externalContentAccess?: (filename: string) => Promise<string>): Promise<che.workspace.devfile.Devfile>
+----
++
+----
+$ async function v1ToV2(devfileV1: che.workspace.devfile.Devfile): Promise<Devfile>
+----

--- a/docs/modules/user-guide/partials/proc_installing-the-devfile-converter.adoc
+++ b/docs/modules/user-guide/partials/proc_installing-the-devfile-converter.adoc
@@ -2,15 +2,16 @@
 = Installing the devfile-converter
 
 [role="_abstract"]
-As you migrate an existing v1.x devfile to a v2.x devfile, consider using the devfile-converter.
+To migrate a devfile from version 1.x to 2.x, install and use the devfile-converter.
 
 .Procedure
 
-* Install the devfile-converter:
+. Install the devfile-converter:
 +
 ----
 $ import * as devfileConverter from '@eclipse-che/devfile-converter';
 ----
+. Convert the devfile-converter:
 +
 ----
 $ async function v2ToV1(devfileV2: Devfile, externalContentAccess?: (filename: string) => Promise<string>): Promise<che.workspace.devfile.Devfile>


### PR DESCRIPTION
Fixes https://github.com/devfile/api/issues/722 

The issue asked to reference this link: https://www.npmjs.com/package/@eclipse-che/devfile-converter 

I know Red Hat discourages to link to external webpages. So I included this content as new documents. Please let me know what you think, thanks! 