### PR TITLE
fix: GitHub action to checkout entire git history 

### DIFF
--- a/.github/workflows/publication-builder.yml
+++ b/.github/workflows/publication-builder.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Build using antora
         run: tools/publication-builder.sh
       - name: Commit artifact to publication branch


### PR DESCRIPTION
To enable publishing multiple versions, the GitHub action needs to fetch more than just one commit.