### PR TITLE
fix: Error: Parameter token or opts.auth is required

### DIFF
--- a/.github/workflows/call-publication-builder.yml
+++ b/.github/workflows/call-publication-builder.yml
@@ -17,3 +17,5 @@ jobs:
   call-publication-builder:
     name: "Call publication builder"
     uses: devfile/docs/.github/workflows/publication-builder.yml@master
+    with:
+      DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}

--- a/.github/workflows/publication-builder.yml
+++ b/.github/workflows/publication-builder.yml
@@ -11,6 +11,9 @@ name: Publication build
 on:
   # Reusable workflow. Called on push on the content branches.
   workflow_call:
+    secrets:
+      DOCS_DEPLOY_TOKEN:
+        required: true
 jobs:
   publication-builder:
     name: Build and publish to publication branch


### PR DESCRIPTION
It seems to avoid errors we need to:
* explicitely set ${{ secrets.DOCS_DEPLOY_TOKEN }}
* do not set ${{ secrets.GITHUB_TOKEN }}

Implementing https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow