### PR TITLE
update the rest api doc link

### DIFF
--- a/docs/modules/user-guide/partials/assembly_devfile-registry.adoc
+++ b/docs/modules/user-guide/partials/assembly_devfile-registry.adoc
@@ -22,4 +22,4 @@ Get started with devfile registries:
 * xref:creating-a-devfile-stack.adoc[]
 * xref:adding-a-stack-yaml-file.adoc[]
 
-For more information on the devfile registry, see the link:https://github.com/johnmcollier/registry-docs/blob/main/registry-REST-API.adoc[Registry REST API].
+For more information on the devfile registry, see the link:https://github.com/devfile/registry-support/blob/main/index/server/registry-REST-API.adoc[Registry REST API].


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

For issue: https://github.com/devfile/api/issues/838

This PR updated the registry REST API doc link. should not point to john's personal repo, the REST API has been updated & moved to registry-support repo. 