### PR TITLE
fix: typo - can't have spaces in ids of...

### DIFF
--- a/docs/modules/user-guide/partials/proc_adding-exec-commands-to-a-devfile.adoc
+++ b/docs/modules/user-guide/partials/proc_adding-exec-commands-to-a-devfile.adoc
@@ -33,7 +33,7 @@ components:
         - name: GOCACHE
           value: /tmp/go-cache
 commands:
-  - id: compile and run
+  - id: compile-and-run
     exec:
       component: go-cli
       commandLine: "go get -d && go run main.go"


### PR DESCRIPTION
fix: typo - can't have spaces in ids of commands (CRW-3200)

Change-Id: I2ad6f7b7ba334b887fa34b5b46c952d4302b11d6
Signed-off-by: Nick Boldt <nboldt@redhat.com>